### PR TITLE
OwO accent update

### DIFF
--- a/Content.Server/Speech/EntitySystems/OwOAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/OwOAccentSystem.cs
@@ -8,12 +8,13 @@ namespace Content.Server.Speech.EntitySystems
         [Dependency] private readonly IRobustRandom _random = default!;
 
         private static readonly IReadOnlyList<string> Faces = new List<string>{
-            " (・`ω´・)", " ;;w;;", " owo", " UwU", " >w<", " ^w^"
+            " (@`ω´@)", " ;;w;;", " owo", " UwU", " >w<", " ^w^"
         }.AsReadOnly();
 
         private static readonly IReadOnlyDictionary<string, string> SpecialWords = new Dictionary<string, string>()
         {
             { "you", "wu" },
+            { "ты", "ти" }, // Corvax-Localization
         };
 
         public override void Initialize()
@@ -29,6 +30,13 @@ namespace Content.Server.Speech.EntitySystems
             }
 
             return message.Replace("!", _random.Pick(Faces))
+                // Corvax-Localization-Start
+                .Replace("р", "в").Replace("Р", "В")
+                .Replace("л", "в").Replace("Л", "В")
+                .Replace("на", "ня").Replace("На", "Ня").Replace("нА", "нЯ").Replace("НА", "НЯ")
+                .Replace("ма", "мя").Replace("Ма", "Мя").Replace("мА", "мЯ").Replace("МА", "МЯ")
+                .Replace("!", "~!").Replace("?", "~?")
+                // Corvax-Localization-End
                 .Replace("r", "w").Replace("R", "W")
                 .Replace("l", "w").Replace("L", "W");
         }


### PR DESCRIPTION
Revert changes back to Corvax with own sprinkles on top to allow for russian-speaking nekos to exist.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Changed OwOAccent file to allow for russian-speaking nekos to exist.
