### PR TITLE
Nuclear Fissure Device Codes Hotfix

### DIFF
--- a/Resources/Locale/ru-RU/nuke/nuke-component.ftl
+++ b/Resources/Locale/ru-RU/nuke/nuke-component.ftl
@@ -4,13 +4,14 @@ nuke-component-announcement-armed = Внимание! Механизм само�
 nuke-component-announcement-unarmed = Механизм самоуничтожение станции деактивирован! Хорошего дня!
 nuke-component-announcement-send-codes = Внимание! Запрошенные коды самоуничтожения были отправлены на консоли связи.
 nuke-component-doafter-warning = Вы начинаете перебирать провода и кнопки, в попытке обезвредить ядерную бомбу. Это может занять некоторое время.
+
+# Nuke UI
 nuke-user-interface-title = Ядерная боеголовка
 nuke-user-interface-arm-button = ВЗВЕСТИ
 nuke-user-interface-anchor-button = ЗАКРЕПИТЬ
 nuke-user-interface-eject-button = ИЗВЛЕЧЬ
 
 ## Upper status
-
 nuke-user-interface-first-status-device-locked = УСТРОЙСТВО ЗАБЛОКИРОВАНО
 nuke-user-interface-first-status-input-code = ВВЕДИТЕ КОД
 nuke-user-interface-first-status-input-time = ВВЕДИТЕ ВРЕМЯ
@@ -20,17 +21,19 @@ nuke-user-interface-first-status-device-cooldown = ДЕАКТИВИРОВАНО
 nuke-user-interface-status-error = ОШИБКА
 
 ## Lower status
-
 nuke-user-interface-second-status-await-disk = ОЖИДАНИЕ ДИСКА
 nuke-user-interface-second-status-time = ВРЕМЯ: {$time}
 nuke-user-interface-second-status-current-code = КОД: {$code}
 nuke-user-interface-second-status-cooldown-time = ОЖИДАНИЕ: {$time}
+
+## Nuke labels
 nuke-label-nanotrasen = NT-{$serial}
+
 # do you even need this one? It's more funnier to say that
 # the Syndicate stole a NT nuke
 nuke-label-syndicate = SYN-{$serial}
 
 # Codes
-
-nuke-codes-message = [color=red]СОВЕРШЕННО СЕКРЕТНО![/color] Код активации ядерной боеголовки: {$name} - {$code}
+nuke-codes-message = [color=red]СОВЕРШЕННО СЕКРЕТНО![/color]
+nuke-codes-list = {$name}, код: {$code}
 nuke-codes-fax-paper-name = коды ядерной аутентификации


### PR DESCRIPTION
Changes the ru-RU translation relating to the nuke so that it is compatible with the current nukecodes data formatting.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->


**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Nukecodes display
